### PR TITLE
Bump Avalonia to 11.0.999-cibuild0023734-beta

### DIFF
--- a/build/Avalonia.Desktop.props
+++ b/build/Avalonia.Desktop.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia.Desktop" Version="11.0.0-preview1" />
+    <PackageReference Include="Avalonia.Desktop" Version="11.0.999-cibuild0023734-beta" />
   </ItemGroup>
 </Project>

--- a/build/Avalonia.Diagnostics.props
+++ b/build/Avalonia.Diagnostics.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.0.0-preview1" />
+    <PackageReference Include="Avalonia.Diagnostics" Version="11.0.999-cibuild0023734-beta" />
   </ItemGroup>
 </Project>

--- a/build/Avalonia.ReactiveUI.props
+++ b/build/Avalonia.ReactiveUI.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.0-preview1" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="11.0.999-cibuild0023734-beta" />
   </ItemGroup>
 </Project>

--- a/build/Avalonia.Themes.Fluent.props
+++ b/build/Avalonia.Themes.Fluent.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.0-preview1" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.999-cibuild0023734-beta" />
   </ItemGroup>
 </Project>

--- a/build/Avalonia.Web.Blazor.props
+++ b/build/Avalonia.Web.Blazor.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia.Web.Blazor" Version="11.0.0-preview1" />
+    <PackageReference Include="Avalonia.Web.Blazor" Version="11.0.999-cibuild0023734-beta" />
   </ItemGroup>
 </Project>

--- a/build/Avalonia.props
+++ b/build/Avalonia.props
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.0.0-preview1" />
+    <PackageReference Include="Avalonia" Version="11.0.999-cibuild0023734-beta" />
   </ItemGroup>
 </Project>

--- a/build/Base.props
+++ b/build/Base.props
@@ -1,7 +1,7 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <VersionPrefix>11.0.0</VersionPrefix>
-    <VersionSuffix>preview1</VersionSuffix>
+    <VersionPrefix>11.0.999</VersionPrefix>
+    <VersionSuffix>cibuild0023734-beta</VersionSuffix>
     <Authors>Wiesław Šoltés</Authors>
     <Company>Wiesław Šoltés</Company>
     <Copyright>Copyright © Wiesław Šoltés 2022</Copyright>


### PR DESCRIPTION
Published as `Avalonia.Xaml.Interactions.11.0.999-cibuild0023734-beta`, `Avalonia.Xaml.Interactivity.11.0.999-cibuild0023734-beta`, and `Avalonia.Xaml.Behaviors.11.0.999-cibuild0023734-beta` on https://gitlab.com/api/v4/projects/32953869/packages/nuget/index.json